### PR TITLE
Update SimpleServer.java

### DIFF
--- a/android/Utils/src/com/googlecode/android_scripting/SimpleServer.java
+++ b/android/Utils/src/com/googlecode/android_scripting/SimpleServer.java
@@ -197,7 +197,7 @@ public abstract class SimpleServer {
     try {
       // address = getPublicInetAddress();
       address = null;
-      mServer = new ServerSocket(port, 5 /* backlog */, address);
+      mServer = new ServerSocket(port, 5 /* backlog */); //just bind to all interfaces
     } catch (Exception e) {
       Log.e("Failed to start server.", e);
       return null;


### PR DESCRIPTION
Since it's supposed to be public, why not bind on all interfaces?  I'm having a problem connecting to a server that is getting an ipv6 address, but my tools can't reach it.  Since there is no configuration to this on the server side, just bind to all interfaces and let the user figure out which ips the device has.
